### PR TITLE
Updated to v0.22.1

### DIFF
--- a/hugo.nuspec
+++ b/hugo.nuspec
@@ -23,7 +23,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>0.20.5</version>
+    <version>0.22.1</version>
     <!-- <packageSourceUrl>Where is this Chocolatey package located (think GitHub)? packageSourceUrl is highly recommended for the community feed</packageSourceUrl>-->
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <!--<owners>__REPLACE_YOUR_NAME__</owners>-->

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,2 +1,20 @@
-﻿$ErrorActionPreference = 'Stop'; # stop on all errors
-Install-ChocolateyZipPackage -packageName 'hugo' -UnzipLocation $(Split-Path -Parent $MyInvocation.MyCommand.Definition) -Url 'https://github.com/spf13/hugo/releases/download/v0.20.5/hugo_0.20.5_Windows-32bit.zip' -checksum '9237B0281FF97EEBB29FFCB6A73DD712F7F5EACCD9357E2593D8D2F418DCF979' -checksumType 'sha256'-Url64 'https://github.com/spf13/hugo/releases/download/v0.20.5/hugo_0.20.5_Windows-64bit.zip' -checksum64 '194AF4D59D76D5A4BB1E3F2E594090D47F9E1CFD4C7790FC0D0B6D6A7E153EFB' -checksumType64 'sha256'
+﻿$ErrorActionPreference = 'Stop'
+
+$packageName= $env:ChocolateyPackageName
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url        = "https://github.com/spf13/hugo/releases/download/v$($env:ChocolateyPackageVersion)/hugo_$($env:ChocolateyPackageVersion)_Windows-32bit.zip"
+$url64      = "https://github.com/spf13/hugo/releases/download/v$($env:ChocolateyPackageVersion)/hugo_$($env:ChocolateyPackageVersion)_Windows-64bit.zip"
+
+$packageArgs = @{
+  packageName   = $packageName
+  unzipLocation = $toolsDir
+  url           = $url
+  url64bit      = $url64
+
+  checksum      = '5F934C4B526C09D1A9AA31544C6EBC80812A0A2058D1304E855B8644DA2CEC48'
+  checksumType  = 'sha256'
+  checksum64    = '8315AD92DA1F21932F86E85B4A816108209AE8A305270E975B30396F67A37D19'
+  checksumType64= 'sha256'
+}
+
+Install-ChocolateyZipPackage @packageArgs

--- a/tools/chocolateyUninstall.ps1
+++ b/tools/chocolateyUninstall.ps1
@@ -1,4 +1,4 @@
-$ErrorActionPreference = 'Stop'; # stop on all errors
+$ErrorActionPreference = 'Stop';
 
 $hugoExe = Get-ChildItem $(Split-Path -Parent $MyInvocation.MyCommand.Definition) | Where-Object -Property Name -Match "hugo.exe"
 


### PR DESCRIPTION
I've updated this to version 0.22.1 and did the following:

1. Updated the chocolateyInstall.ps1 so that it only needs the checksum's updating for a new version. It will download the correct version from the Github page based on the version number in the .nuspec (using $env:ChocolateyPackageVersion). The changes to this file also make it a lot more readable (IMO);

2. Updated the .nuspec file with the new version;

3. Removed unnecessary comments in the .ps1 files;