### PR TITLE
Add AppVeyor support.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,15 @@
+version: 0.{build}
+environment:
+  TOKEN:  #[API_KEY_HERE] Go to "https://ci.appveyor.com/tools/encrypt" page in account menu to encrypt data and place secure key from chocolatey into it, and new account bound key here.
+    secure: fglJKa/F1FlVu+oA2uZDN3R0pE5iVGYVjP1EAR/0FvPjQB1hivwd5ujOdkplBQ+Q
+
+build_script:
+  - ps: choco pack
+
+test_script:
+  - ps: Get-Content .\tests.ps1 | PowerShell.exe -noprofile - #allows unsigned scripts to run
+
+deploy_script:
+  - ps: choco apiKey --key $env:TOKEN --source https://push.chocolatey.org/
+  - ps: $packageName = (Get-ChildItem hugo.*.nupkg).name
+  - ps: choco push $packageName --source https://push.chocolatey.org/

--- a/tests.ps1
+++ b/tests.ps1
@@ -1,0 +1,22 @@
+"Running tests"
+$ErrorActionPreference = "Stop"
+
+"TEST: Installation of package should work"
+choco install hugo -s "$pwd" -y -f
+try {
+  hugo version
+  Write-Host "PASS: hugo found"
+} catch {
+  Write-Error "FAIL: hugo not found"
+}
+
+"TEST: Uninstall show remove the binary"
+choco uninstall hugo -y
+try {
+  hugo version
+  Write-Error "FAIL: hugo binary still found" 
+} catch {
+  Write-Host "PASS: hugo not found"
+}
+
+"TEST: Finished"


### PR DESCRIPTION
This adds simple automated support for pushing updates to chocolatey.
- Change TOKEN: secure: key to your own secure key created on appveyor from your chocolatey key. 
- Update process still same (change version, update nuspec, update checksums etc.)
- Appveyor will then run pack, test install/uninstall and apikey add and push it to chocolatey.

Notes: 
 - Choco will auto reject hugo.nuspec versions that are the same.
 - no readme update.